### PR TITLE
Add GitHub action to publish on pypi upon release

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,25 @@
+name: publish_pypi
+
+on: 
+  release:
+    types: [published, edited]
+
+jobs:
+    build-and-publish:
+      name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+      runs-on: ubuntu-18.04
+      steps:
+        - uses: actions/checkout@v1
+        - name: Setup Python 3.7
+          uses: actions/setup-python@v1
+          with:
+            python-version: 3.7
+        - name: Build distribution
+          run: |
+            pip install wheel
+            python setup.py sdist bdist_wheel
+        - name: Publish distribution 📦 to PyPI
+          uses: pypa/gh-action-pypi-publish@master
+          with:
+            password: ${{ secrets.PYPI_TOKEN }}
+


### PR DESCRIPTION
With this action, whenever a new release is published, the python distribution will be built automatically and uploaded on PyPi.
One thing for the maintainer if merging this PR: add the [PYPI_TOKEN](https://pypi.org/help/#apitoken) in the [github secrets](https://docs.github.com/en/actions/reference/encrypted-secrets)
